### PR TITLE
Fix stray comment text in analysis pages

### DIFF
--- a/pages/cluster_strategie.py
+++ b/pages/cluster_strategie.py
@@ -15,7 +15,7 @@ if not is_premium:
     st.info("🔓 [Upgrade auf Premium](https://example.com/upgrade)")
     st.stop()
 
-# CSV wird global aus Sidebar geladen\nuploaded_file = st.session_state.get('csv_data', None)"📄 Ziehungsdaten (CSV)", type="csv")
+# CSV wird global aus der Sidebar geladen
 
 @st.cache_data
 def lade_zahlen(datei):

--- a/pages/dashboard.py
+++ b/pages/dashboard.py
@@ -9,7 +9,7 @@ st.title("📊 EuroGenius Dashboard")
 
 email = st.session_state.get("user_email", "gast@demo.com")
 
-# CSV wird global aus Sidebar geladen\nuploaded_file = st.session_state.get('csv_data', None)"📥 Letzte Ziehungsdaten (CSV)", type="csv", help="Lade deine aktuelle EuroMillion-Ziehungsdatei hoch.")
+# CSV wird global aus der Sidebar geladen
 
 if uploaded_file is not None:
     df = uploaded_file

--- a/pages/gewinnmuster.py
+++ b/pages/gewinnmuster.py
@@ -7,7 +7,7 @@ st.set_page_config(page_title="📈 Gewinnmuster & Trends", layout="wide")
 uploaded_file = st.session_state.get('csv_data', None)
 st.title("📈 Gewinnmuster & Statistische Trends")
 
-# CSV wird global aus Sidebar geladen\nuploaded_file = st.session_state.get('csv_data', None)"📄 Ziehungsdaten (CSV)", type="csv")
+# CSV wird global aus der Sidebar geladen
 
 if uploaded_file is not None:
     df = uploaded_file

--- a/pages/universelle_analyse.py
+++ b/pages/universelle_analyse.py
@@ -7,7 +7,7 @@ st.set_page_config(page_title="♾️ Universelle Muster & Quantenanalyse", layo
 uploaded_file = st.session_state.get('csv_data', None)
 st.title("♾️ Universelle Muster & Quanten-Logik")
 
-# CSV wird global aus Sidebar geladen\nuploaded_file = st.session_state.get('csv_data', None)"📄 Ziehungsdaten (CSV)", type="csv")
+# CSV wird global aus der Sidebar geladen
 
 fibonacci_set = set([0, 1])
 a, b = 0, 1


### PR DESCRIPTION
## Summary
- cleanup leftover comment text referencing old file uploader logic in analysis pages

## Testing
- `python -m py_compile pages/dashboard.py pages/gewinnmuster.py pages/cluster_strategie.py pages/universelle_analyse.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68416cfd5938833183addba883158091